### PR TITLE
[ADD]gitignore, ajout des fichiers de compilation pour le back en go et CI/CD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,11 @@ public/uploads/
 /storage/logs/
 bootstrap/cache/
 vendor/
+
+
+# === Fichiers compilés ===
+
+*.out
+*.exe
+*.class
+*.o


### PR DESCRIPTION
## Objectif de cette Pull Request
- Ajout de la suppression des fichiers temporaires liés au back en go et de la CI/CD

## 🔗 Issue associée
Closes #27 

## ✅ Checklist
- [x] Commit signé et vérifié (`Verified`)
- [x] Ajout d'un fichier dans `branche1`
- [x] PR prête à être fusionnée